### PR TITLE
added Tune to dataset name

### DIFF
--- a/gridpack.py
+++ b/gridpack.py
@@ -391,7 +391,7 @@ class Gridpack():
         campaign_dict = self.get_campaign_dict()
         energy = float(campaign_dict.get('beam', 0) * 2)
         energy = ('%.2f' % (energy / 1000)).rstrip('.0').replace('.', 'p')
-        tune_energy = f'{tune}_{energy}TeV'
+        tune_energy = f'Tune{tune}_{energy}TeV'
         dataset_name = dataset.split('_')
         dataset_name.insert(-1, tune_energy)
         dataset_name = '_'.join(dataset_name)


### PR DESCRIPTION
Dear all, I propose a small change. In the past and the official dataset rules we used to have 
something_TuneCP5_something. The current logic only has something_CP5_something. 
I would propose to switch back. What do you think? 
@sihyunjeon @jordan-martins who is merging these days ? 
This is also how we denoted in the google doc: 
https://docs.google.com/spreadsheets/d/1xEbHtxzJVaWJpxDrJ7tSpxcVQMRIFbZeoeO7davNFMA/edit#gid=1396344675
Let me know. 