### PR TITLE
Store Gridpacks into subfolders & Set request attributes in McM

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -485,7 +485,7 @@ class Controller():
                        f'--chain "{chain}" '
                        f'--dataset "{dataset_name}" '
                        f'--events "{events}" '
-                       f'--tag "{process}"'
+                       f'--tag "{process}" '
                        f'--generator "{generator}"'
                        ]
             stdout, stderr, _ = ssh.execute_command(command)

--- a/controller.py
+++ b/controller.py
@@ -375,8 +375,11 @@ class Controller():
             if gridpack_archive:
                 gridpack_directory = Config.get('gridpack_directory')
                 if not Config.get('dev'):
-                    campaign_dict = gridpack.get_campaign_dict()
-                    gridpack_directory = campaign_dict.get('gridpack_directory', gridpack_directory)
+                    # Set the path to cvmfs and include generator, process too
+                    gridpack_directory = (
+                        f'/eos/cms/store/group/phys_generator/cvmfs/gridpacks/PdmV/{gridpack.get("campaign")}'
+                        f'/{gridpack.get("generator")}/{gridpack.get("process")}'
+                    )
 
                 self.logger.info('Copying gridpack %s/%s->%s', remote_directory, gridpack_archive, gridpack_directory)
                 stdout, stderr, _ = ssh.execute_command(f'rsync -e "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" {remote_directory}/{gridpack_archive} lxplus.cern.ch:{gridpack_directory}')

--- a/controller.py
+++ b/controller.py
@@ -436,6 +436,7 @@ class Controller():
         dataset_name = gridpack.get('dataset_name')
         events = gridpack.get('events')
         process = gridpack.get('process')
+        generator = gridpack.get('generator')
 
         with SSHExecutor(tickets_host, ssh_credentials) as ssh:
             ssh.execute_command([f'rm -rf {remote_directory}',
@@ -453,6 +454,7 @@ class Controller():
                        f'--dataset "{dataset_name}" '
                        f'--events "{events}" '
                        f'--tag "{process}"'
+                       f'--generator "{generator}"'
                        ]
             stdout, stderr, _ = ssh.execute_command(command)
             self.logger.debug(stdout)

--- a/fragment_builder.py
+++ b/fragment_builder.py
@@ -1,6 +1,7 @@
 import os
 import json
 import logging
+from gridpack import Gridpack
 from config import Config
 from utils import get_indentation
 from os.path import join as path_join
@@ -53,7 +54,7 @@ class FragmentBuilder():
 
         return '%s\n' % (contents.strip())  # Add newline to the end of the contents
 
-    def fragment_replace(self, fragment, gridpack):
+    def fragment_replace(self, fragment, gridpack: Gridpack):
         with open(self.imports_path) as input_file:
             import_dict = json.load(input_file)
 
@@ -67,13 +68,7 @@ class FragmentBuilder():
         fragment_vars['comEnergy'] = int(beam * 2)
         fragment_vars['tuneImport'] = import_dict['tune'][tune]
         archive_path = Config.get('gridpack_directory')
-        if not Config.get('dev'):
-            # Set the path to cvmfs and include generator, process too
-            archive_path = (
-                f'/cvmfs/cms.cern.ch/phys_generator/gridpacks/PdmV/{gridpack.get("campaign")}'
-                f'/{gridpack.get("generator")}/{gridpack.get("process")}'
-            )
-            
+        archive_path = gridpack.get_remote_storage_path()
         archive_name = gridpack.get('archive') or 'Nothing.zip'
         fragment_vars['pathToProducedGridpack'] = os.path.join(archive_path, archive_name)
         for key, value in fragment_vars.items():

--- a/fragment_builder.py
+++ b/fragment_builder.py
@@ -68,12 +68,12 @@ class FragmentBuilder():
         fragment_vars['tuneImport'] = import_dict['tune'][tune]
         archive_path = Config.get('gridpack_directory')
         if not Config.get('dev'):
-            campaign_dict = gridpack.get_campaign_dict()
-            archive_path = campaign_dict.get('gridpack_directory', archive_path)
-
-        # Replace to actual cvmfs
-        archive_path = archive_path.replace('/eos/cms/store/group/phys_generator/cvmfs/gridpacks/',
-                                            '/cvmfs/cms.cern.ch/phys_generator/gridpacks/', )
+            # Set the path to cvmfs and include generator, process too
+            archive_path = (
+                f'/cvmfs/cms.cern.ch/phys_generator/gridpacks/PdmV/{gridpack.get("campaign")}'
+                f'/{gridpack.get("generator")}/{gridpack.get("process")}'
+            )
+            
         archive_name = gridpack.get('archive') or 'Nothing.zip'
         fragment_vars['pathToProducedGridpack'] = os.path.join(archive_path, archive_name)
         for key, value in fragment_vars.items():

--- a/fragment_builder.py
+++ b/fragment_builder.py
@@ -69,6 +69,8 @@ class FragmentBuilder():
         fragment_vars['tuneImport'] = import_dict['tune'][tune]
         archive_path = Config.get('gridpack_directory')
         archive_path = gridpack.get_remote_storage_path()
+        archive_path = archive_path.replace('/eos/cms/store/group/phys_generator/cvmfs/gridpacks/',
+                                            '/cvmfs/cms.cern.ch/phys_generator/gridpacks/', )
         archive_name = gridpack.get('archive') or 'Nothing.zip'
         fragment_vars['pathToProducedGridpack'] = os.path.join(archive_path, archive_name)
         for key, value in fragment_vars.items():

--- a/gridpack.py
+++ b/gridpack.py
@@ -33,6 +33,7 @@ class Gridpack():
         'dataset_name': '',
         'history': [],
         'prepid': '',
+        'store_into_subfolders': False
     }
 
     def __init__(self, data):
@@ -233,6 +234,29 @@ class Gridpack():
         local_dir = self.local_dir()
         job_files = os.path.join(local_dir, 'input_files')
         return job_files
+
+    def get_remote_storage_path(self) -> str:
+        """
+        Retrieves the remote storage path for saving the resulting
+        Gridpack. For production environments, Gridpacks will be stored into
+        GEN group folder in /eos/
+
+        Returns:
+            str: Gridpack remote storage path
+        """
+        store_into_subfolders: bool = self.data.get("store_into_subfolders", False)
+        gridpack_directory: str = Config.get("gridpack_directory")
+        if not Config.get("dev"):
+            if store_into_subfolders:
+                gridpack_directory = (
+                    f'/eos/cms/store/group/phys_generator/cvmfs/gridpacks/PdmV/{self.get("campaign")}'
+                    f'/{self.get("generator")}/{self.get("process")}'
+                )
+            else:
+                gridpack_directory = (
+                    f'/eos/cms/store/group/phys_generator/cvmfs/gridpacks/PdmV/{self.get("campaign")}'
+                )
+        return gridpack_directory
 
     def mkdir(self):
         """

--- a/gridpack.py
+++ b/gridpack.py
@@ -244,11 +244,7 @@ class Gridpack():
         Returns:
             str: Gridpack remote storage path
         """
-<<<<<<< HEAD
         store_into_subfolders: bool = self.data.get("store_into_subfolders", False)
-=======
-        store_into_subfolders: bool = self.get("store_into_subfolders")
->>>>>>> 5749015855486cada94ac9c008013358b87fef8a
         gridpack_directory: str = Config.get("gridpack_directory")
         if not Config.get("dev"):
             if store_into_subfolders:

--- a/main.py
+++ b/main.py
@@ -89,6 +89,28 @@ def system_info():
                         'gen_repository': Config.get('gen_repository')})
 
 
+@app.route('/api/mcm', methods=['POST'])
+def force_mcm_request():
+    """
+    This endpoint forces the creation for a request in McM
+    for a completed Gridpack
+    """
+    if not is_user_authorized():
+        return output_text({'message': 'Unauthorized'}, code=403)
+    
+    gridpack_id: str = request.args.get('gridpack_id', '')
+    if not gridpack_id:
+        return output_text(
+            {'message': 'Please choose a Gridpack via request parameter "gridpack_id"'},
+            code=400
+        )
+    
+    force_status = controller.force_request_for_gridpack(gridpack_id=gridpack_id)
+    if isinstance(force_status, dict):
+        return output_text(data=force_status, code=400)
+    
+    return output_text({'message': 'Request forced for %s' % gridpack_id})
+
 @app.route('/api/create', methods=['PUT'])
 def create_gridpack():
     """

--- a/mcm_gridpack.py
+++ b/mcm_gridpack.py
@@ -8,7 +8,7 @@ from rest import McM
 mcm = None
 
 
-def create_request(fragment_file, dataset_name, chain, events, tag):
+def create_request(fragment_file, dataset_name, chain, events, tag, generator):
     campaign = chain.split('_')[1]
     print('Creating request in %s' % (campaign))
     request_json = {'pwg': 'GEN',
@@ -28,6 +28,8 @@ def create_request(fragment_file, dataset_name, chain, events, tag):
     request['fragment'] = fragment
     request['total_events'] = events
     request['tags'] = [tag]
+    request['mcdb_id'] = 0
+    request['generators'] = [generator]
     result = mcm.update('requests', request)
     print(result)
 
@@ -40,10 +42,18 @@ def main():
     parser.add_argument('--fragment')
     parser.add_argument('--events', type=int)
     parser.add_argument('--tag')
+    parser.add_argument('--generator')
     args = vars(parser.parse_args())
     global mcm
     mcm = McM(dev=args['dev'])
-    create_request(args['fragment'], args['dataset'], args['chain'], args['events'], args['tag'])
+    create_request(
+        args['fragment'], 
+        args['dataset'], 
+        args['chain'], 
+        args['events'], 
+        args['tag'], 
+        args['generator']
+    )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
1. Modify the old storage path to store Gridpacks into subfolders depending on its generator and process. This stops using the attribute ‘gridpack_directory’ available in the campaign’s JSON.
2. Update some attributes in McM for requests created from generated Gridpacks:

- Set `mcdb_id` to zero
- Set generators attribute with Gridpack's generator