### PR TITLE
Cores and memory

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -34,6 +34,8 @@ class Controller():
         self.gridpacks_to_create_requests = []
         self.repository_tick_pause = 60
         self.tick_lock = Lock()
+        self.job_cores = [4, 8, 16, 32, 64]
+        self.job_memory = [cores * 1000 for cores in self.job_cores]
 
     def update_repository_tree(self):
         now = int(time.time())

--- a/controller.py
+++ b/controller.py
@@ -34,7 +34,7 @@ class Controller():
         self.gridpacks_to_create_requests = []
         self.repository_tick_pause = 60
         self.tick_lock = Lock()
-        self.job_cores = [4, 8, 16, 32, 64]
+        self.job_cores = [1, 2, 4, 8, 16, 32, 64]
         self.job_memory = [cores * 1000 for cores in self.job_cores]
 
     def update_repository_tree(self):

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -163,6 +163,8 @@
         <th>
           <span class="sort" @click="onSort('condor_status')">Job</span>
         </th>
+        <th>Cores</th>
+        <th>Memory</th>
         <th>Gridpack</th>
         <th>PrepID</th>
         <th>
@@ -214,6 +216,16 @@
         <td>
           <pre style="margin: 0">{{gridpack.condor_status}} ({{gridpack.condor_id}})</pre>
         </td>
+        <!-- Number of cores-->
+        <td>
+          <pre v-if="gridpack.job_cores" style="margin: 0">{{gridpack.job_cores}}</pre>
+          <pre v-else style="margin: 0">()</pre>
+        </td>
+        <!-- Memory -->
+        <td>
+          <pre v-if="gridpack.job_memory" style="margin: 0">{{gridpack.job_memory}} MB</pre>
+          <pre v-else style="margin: 0">()</pre>
+        </td>
         <td>
           <a v-if="dev" :href="'https://pdmv-gridpacks.web.cern.ch/?q=' + gridpack.archive" target="_blank" style="letter-spacing: -0.4px">{{gridpack.archive}}</a>
           <span v-if="!dev" style="letter-spacing: -0.4px">{{gridpack.archive}}</span>
@@ -253,6 +265,8 @@
                 <th>Tune</th>
                 <th>Events</th>
                 <th>GEN productions</th>
+                <th>Job cores</th>
+                <th>Job memory</th>
                 <th>Actions</th>
               </tr>
               <tr v-for="(wizardObject, index) in wizardObjects">
@@ -290,6 +304,16 @@
                 <td>
                   <select v-model="wizardObject.genproductions">
                     <option v-for="branch in systemInfo.options.branches" :key="branch">{{branch}}</option>
+                  </select>
+                </td>
+                <td>
+                  <select v-model="wizardObject.job_cores">
+                    <option v-for="cores_option in systemInfo.job_cores" :key="cores_option">{{cores_option}}</option>
+                  </select>
+                </td>
+                <td>
+                  <select v-model="wizardObject.job_memory">
+                    <option v-for="memory_option in systemInfo.job_memory" :key="memory_option">{{memory_option}}</option>
                   </select>
                 </td>
                 <td style="text-align: left;">
@@ -576,6 +600,20 @@
               alert('Please enter a positive number of events in row ' + index);
               return;
             }
+            gridpack.job_cores = parseInt(gridpack.job_cores);
+            if (gridpack.job_cores == undefined || isNaN(gridpack.job_cores)) {
+              alert('Please set the number of cores in row ' + index);
+              return;
+            }
+            gridpack.job_memory = parseInt(gridpack.job_memory);
+            if (gridpack.job_memory == undefined || isNaN(gridpack.job_memory)) {
+              alert('Please set the memory for the job in row ' + index);
+              return;
+            }
+            if (gridpack.job_memory < gridpack.job_cores * 1000) {
+              alert(`Please avoid to set the memory less than ${gridpack.job_cores * 1000} MB in row ${index}`);
+              return;
+            }
             index++;
           }
           this.createGridpacks(this.wizardObjects);
@@ -596,6 +634,8 @@
             events: wizardObject.events,
             tune: wizardObject.tune,
             genproductions: wizardObject.genproductions,
+            job_cores: wizardObject.job_cores,
+            job_memory: wizardObject.job_memory
           });
         },
         wizardMoveRowUp: function(wizardObject) {

--- a/main.py
+++ b/main.py
@@ -86,7 +86,9 @@ def system_info():
     return output_text({'last_tick': controller.last_tick,
                         'last_repository_tick': controller.last_repository_tick,
                         'options': controller.repository_tree,
-                        'gen_repository': Config.get('gen_repository')})
+                        'gen_repository': Config.get('gen_repository'),
+                        'job_cores': controller.job_cores,
+                        'job_memory': controller.job_memory})
 
 
 @app.route('/api/mcm', methods=['POST'])


### PR DESCRIPTION
### Status

Tested.

I have created some test Gridpacks in the [development](https://cms-pdmv-dev.web.cern.ch/gridpack/) instance requesting the following resources:

| **Gridpack ID** | **Cores and memory**  |
|-----------------|-----------------------|
| 1696528806266   | 4 cores and 4000 MB   |
| 1696528806268   | 8 cores and 8000 MB   |
| 1696528806269   | 8 cores and 32000 MB  |
| 1696528806270   | 16 cores and 16000 MB |
| 1696528806271   | 32 cores and 32000 MB |

The number of cores and the memory is properly set in the HTCondor configuration file (.jds)

### Is it backward compatible (if not, which system it affect?)

YES

If old Gridpacks are reset, the number of cores and memory will be set with the default value (16 cores and 32000 MB of memory) for further operations.

### External dependencies / deployment changes

- None