### PR TITLE
Use Kerberos tickets for SSH authentication

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@
 FROM python:3.11.7-alpine3.19@sha256:6aa46819a8ff43850e52f5ac59545b50c6d37ebd3430080421582af362afec97 AS build
 RUN apk update && apk upgrade
 
+# Install Kerberos client and gcc for Python wrapper
+RUN apk add build-base && apk add krb5-dev 
+
 WORKDIR /usr/app
 RUN python -m venv /usr/app/venv
 ENV PATH="/usr/app/venv/bin:$PATH"
@@ -17,6 +20,9 @@ RUN pip install --upgrade pip setuptools wheel
 
 # Install Git - Required to update the Gridpack files repository
 RUN apk add git
+
+# Install the Kerberos client
+RUN apk add krb5-dev 
 
 # User and application folder
 RUN addgroup -g 1001 pdmv && adduser --disabled-password -u 1001 -G pdmv pdmv

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,7 @@ Flask>=3.0.1
 Flask-Cors>=4.0.0 
 Flask-RESTful>=0.3.10
 paramiko>=3.4.0
+gssapi>=1.8.3
+pyasn1>=0.5.1
 pymongo==3.13.0
 pylint>=3.0.3 


### PR DESCRIPTION
1. Include the GSS-API handler for `paramiko` to use this authentication procedure.
2. Update the container image to include the Kerberos client.