### PR TITLE
change email receiver

### DIFF
--- a/src/tools/email_sender.py
+++ b/src/tools/email_sender.py
@@ -49,7 +49,7 @@ class EmailSender:
         body += "\n\nSincerely,\nGridpack Extravaganza Machine"
         ccs = [
             "PdmV Service Account <pdmvserv@cern.ch>",
-            "CMS Automatic Background Production <ppd-auto-bkg@cern.ch>",
+            "CMS Automatic Background Production <ppd-auto-bkg-machine@cern.ch>",
         ]
         # Create a fancy email message
         message = MIMEMultipart()


### PR DESCRIPTION
Changing it to ppd-auto-bkg-machine@cernNOSPAM.ch

Hi Geovanny,

We made a new egroup to restrict the email recipients to me alex carlos only as the original one is subscribed by pdmv and ppd conveners.

@Cvico @agrohsje 

We just have to make sure egroup receives email from non-egroup members which I'll check tmrw and merge