### PR TITLE
Update static links to the new domain

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -251,8 +251,8 @@
           <span v-if="!dev" style="letter-spacing: -0.4px">{{gridpack.archive}}</span>
         </td>
         <td>
-          <a v-if="dev" :href="'https://cms-pdmv-dev.cern.ch/mcm/requests?prepid=' + gridpack.prepid" target="_blank">{{gridpack.prepid}}</a>
-          <a v-else :href="'https://cms-pdmv.cern.ch/mcm/requests?prepid=' + gridpack.prepid" target="_blank">{{gridpack.prepid}}</a>
+          <a v-if="dev" :href="'https://cms-pdmv-dev.web.cern.ch/mcm/requests?prepid=' + gridpack.prepid" target="_blank">{{gridpack.prepid}}</a>
+          <a v-else :href="'https://cms-pdmv-prod.web.cern.ch/mcm/requests?prepid=' + gridpack.prepid" target="_blank">{{gridpack.prepid}}</a>
         </td>
         <td>
           <ul style="text-align: left">


### PR DESCRIPTION
Related to: [PDMVDEV-82](https://its.cern.ch/jira/browse/PDMVDEV-82)

1. Update old references to old production names `cms-pdmv.cern.ch` and `cms-pdmv-dev.cern.ch`